### PR TITLE
Timbre fiscal digital v1.0 - Corrección de defecto en mappeo de objetos tipo dateTime.

### DIFF
--- a/complementos/timbre-fiscal-v10/src/main/xjb/bindings.xjb
+++ b/complementos/timbre-fiscal-v10/src/main/xjb/bindings.xjb
@@ -7,7 +7,7 @@
                     fixedAttributeAsConstantProperty="true">
         <xjc:javaType name="java.time.LocalDateTime"
                       xmlType="xs:dateTime"
-                      adapter="io.github.threetenjaxb.core.LocalDateXmlAdapter" />
+                      adapter="io.github.threetenjaxb.core.LocalDateTimeXmlAdapter" />
     </globalBindings>
 
     <bindings schemaLocation="../xsd/TimbreFiscalDigital.xsd">


### PR DESCRIPTION
closes #111 